### PR TITLE
Add image preview dialog to camera route

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tanstack/react-router": "^1.120.10",
     "@tanstack/react-router-devtools": "^1.120.10",
     "@tanstack/react-start": "^1.120.10",
+    "lucide-react": "^0.513.0",
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@tanstack/react-start':
         specifier: ^1.120.10
         version: 1.120.10(@tanstack/react-router@1.120.10(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/node@22.15.21)(db0@0.3.2)(ioredis@5.6.1)(jiti@2.4.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(terser@5.39.2)(tsx@4.19.4)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(terser@5.39.2)(tsx@4.19.4)(yaml@2.8.0))(yaml@2.8.0)
+      lucide-react:
+        specifier: ^0.513.0
+        version: 0.513.0(react@19.1.0)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2653,6 +2656,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@0.513.0:
+    resolution: {integrity: sha512-CJZKq2g8Y8yN4Aq002GahSXbG2JpFv9kXwyiOAMvUBv7pxeOFHUWKB0mO7MiY4ZVFCV4aNjv2BJFq/z3DgKPQg==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   luxon@3.6.1:
     resolution: {integrity: sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==}
@@ -6768,6 +6776,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@0.513.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   luxon@3.6.1: {}
 

--- a/src/routes/_authed/camera.tsx
+++ b/src/routes/_authed/camera.tsx
@@ -1,11 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import * as React from "react";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-} from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogFooter } from "@/components/ui/dialog";
 import { Toaster } from "@/components/ui/sonner";
 import { toast } from "sonner";
 
@@ -85,14 +81,14 @@ function RouteComponent() {
     const dataUrl = canvas.toDataURL("image/png");
     setCapturedImage(dataUrl);
     toast.custom((t) => (
-      <div className="flex items-center gap-2 w-full">
+      <div className="flex items-center w-full rounded-md">
         <img
           src={dataUrl}
           alt="preview"
-          className="w-12 h-12 object-cover rounded-md"
+          className="w-12 h-12 object-cover rounded-md my-2 ml-2 mr-4"
         />
-        <span className="text-sm">Image captured!</span>
-        <div className="ml-auto">
+        <span className="text-sm mr-10">Image captured!</span>
+        <div className="ml-auto mr-2 rounded-md">
           <Button
             size="sm"
             onClick={() => {
@@ -109,7 +105,12 @@ function RouteComponent() {
 
   return (
     <div className="flex flex-col items-center justify-center min-h-[60vh]">
-      <Toaster position="top-center" />
+      <Toaster
+        position="top-center"
+        toastOptions={{
+          className: "rounded-md bg-white shadow-lg border border-gray-300",
+        }}
+      />
       <h1 className="text-2xl font-bold mb-4">Camera Access</h1>
       {error && <div className="text-red-500 mb-4">{error}</div>}
       <video
@@ -134,7 +135,7 @@ function RouteComponent() {
             <img
               src={capturedImage}
               alt="captured"
-              className="w-full h-auto mb-4"
+              className="w-full h-auto my-4 rounded-md"
             />
           )}
           <DialogFooter>

--- a/src/routes/_authed/camera.tsx
+++ b/src/routes/_authed/camera.tsx
@@ -1,6 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 import * as React from "react";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+} from "@/components/ui/dialog";
 import { Toaster } from "@/components/ui/sonner";
 import { toast } from "sonner";
 
@@ -13,6 +18,8 @@ function RouteComponent() {
   const canvasRef = React.useRef<HTMLCanvasElement>(null);
   const [error, setError] = React.useState<string | null>(null);
   const [hasPermission, setHasPermission] = React.useState(false);
+  const [capturedImage, setCapturedImage] = React.useState<string | null>(null);
+  const [dialogOpen, setDialogOpen] = React.useState(false);
 
   React.useEffect(() => {
     async function getCamera() {
@@ -53,6 +60,19 @@ function RouteComponent() {
     }
   }
 
+  function handleSubmit() {
+    if (capturedImage) {
+      submitImage(capturedImage);
+    }
+    setDialogOpen(false);
+    setCapturedImage(null);
+  }
+
+  function handleDiscard() {
+    setDialogOpen(false);
+    setCapturedImage(null);
+  }
+
   const takeStill = React.useCallback(async () => {
     if (!videoRef.current || !canvasRef.current) return;
     const video = videoRef.current;
@@ -63,8 +83,28 @@ function RouteComponent() {
     if (!ctx) return;
     ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
     const dataUrl = canvas.toDataURL("image/png");
-    toast("Image captured!");
-    submitImage(dataUrl);
+    setCapturedImage(dataUrl);
+    toast.custom((t) => (
+      <div className="flex items-center gap-2 w-full">
+        <img
+          src={dataUrl}
+          alt="preview"
+          className="w-12 h-12 object-cover rounded-md"
+        />
+        <span className="text-sm">Image captured!</span>
+        <div className="ml-auto">
+          <Button
+            size="sm"
+            onClick={() => {
+              setDialogOpen(true);
+              toast.dismiss(t.id);
+            }}
+          >
+            Inspect
+          </Button>
+        </div>
+      </div>
+    ));
   }, []);
 
   return (
@@ -88,6 +128,23 @@ function RouteComponent() {
           Take Still
         </Button>
       )}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          {capturedImage && (
+            <img
+              src={capturedImage}
+              alt="captured"
+              className="w-full h-auto mb-4"
+            />
+          )}
+          <DialogFooter>
+            <Button variant="outline" onClick={handleDiscard}>
+              Discard
+            </Button>
+            <Button onClick={handleSubmit}>Submit</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- preview taken image in toast with Inspect button
- open Dialog with full-size image to submit or discard
- add lucide-react dependency for Dialog icon

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68410fc12bc48332897d37b01009e27c